### PR TITLE
lib/main: fix getPayload()

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -87,9 +87,10 @@ function getRequestInfo(channel) {
  * Return the POST payload from an nsIHttpChannel.
  *
  * @param nsIHttpChannel httpChannel
+ * @param nsIHttpHeaderVisitor headerVisitor
  * @return string|null
  */
-function getPayload(httpChannel) {
+function getPayload(httpChannel, headerVisitor) {
   let inputStream = httpChannel.QueryInterface(Ci.nsIUploadChannel).uploadStream;
   if (!inputStream)
     return null;
@@ -103,6 +104,8 @@ function getPayload(httpChannel) {
     {}
   );
 
+  inputStream.seek(0, originalStreamPos); // back to its original position
+
   let i = response.indexOf("\r\n\r\n");
   let headers = response.substring(0, i);
   let payload = response.substring(i + 4);
@@ -113,8 +116,6 @@ function getPayload(httpChannel) {
   headerVisitor.headers = headerVisitor.headers.concat(
       headers.split("\r\n")
   );
-
-  inputStream.seek(0, originalStreamPos); // back to its original position
 
   return payload;
 }


### PR DESCRIPTION
Added the missing parameter
Moved `inputStream.seek(0, originalStreamPos);` forward